### PR TITLE
Bump Node Docker image from argon to buster

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:argon
+FROM node:buster
 
 RUN ["adduser",  "--home",  "/usr/src/app", "--system", "sandboxuser"]
 RUN ["chown", "-R", "sandboxuser", "/usr/src/app"]


### PR DESCRIPTION
HI,

not sure if it's the right solution, but when building the docker image:

docker build -t christophetd/docker-sandbox .

I got the error:

`File "/usr/bin/pip3", line 5, in <module> from pkg_resources import load_entry_point File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 81, in <module> raise RuntimeError("Python 3.5 or later is required") RuntimeError: Python 3.5 or later is required`

It seems node:argon uses Python 3.4.2
After the update to node:buster the python version is Python 3.7.3 and the build worked for me.

Thanks